### PR TITLE
fix for state storing partial-second timestamp

### DIFF
--- a/tap_newrelic/streams.py
+++ b/tap_newrelic/streams.py
@@ -64,7 +64,11 @@ class NewRelicStream(GraphQLStream):
         )
 
     def get_url_params(self, partition, next_page_token: Optional[DateTimeType] = None) -> dict:
-        next_page_token = next_page_token or self.get_starting_timestamp(partition)
+        if not next_page_token:
+            next_page_token = self.get_starting_timestamp(partition)
+            self.latest_timestamp = next_page_token.isoformat()
+        # NQRL only supports timestamps to second resolution
+        next_page_token = next_page_token.set(microsecond=0)
         nqrl = self.nqrl_query.format(
             next_page_token.strftime(self.datetime_format),
             self.get_replication_key_signpost(partition).strftime(self.datetime_format),


### PR DESCRIPTION
Thanks to NQRL only using second-resolution for timestamps, the same issue with out-of-order results in rows also applies to state. This fixes that issue.